### PR TITLE
Update RFP/Razoring conditions and add proper pruning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ position startpos
 go infinite
 ```
 
-## Upcoming Development
-- Texel tuning evaluation weights
-- Add SEE
-- Search improvements and optimizations
-- Once I'm bored of improving the HCE and search, switch to NNUE!
+## Engine Testing
+
+SPRT command:
+```
+cutechess-cli -engine proto=uci cmd={BINARY_TO_TEST} name={TEST_NAME} -engine proto=uci cmd={EXISTING_VERISON_BINARY} name={EXISTING_NAME} -each tc=8+0.08 option.Hash=32 -games 2 -rounds 1000 -repeat -concurrency 8 -openings file={PATH_TO_EPD} format=epd order=random -pgnout {PATH_TO_PGN} -sprt elo0=0 elo1=5 alpha=0.05 beta=0.1 -ratinginterval 10
+```
 
 ## References
 Definitely the most helpful reference in developing this engine for me has been the Chess Programming [wiki](https://www.chessprogramming.org/Main_Page)! If you're interested in developing your own chess engine or move library, this website has everything. Also want to shoutout [Blunder](https://github.com/deanmchris/blunder) as a great and readable reference for helping me improve the engine!


### PR DESCRIPTION
*SPRT*: alpha=0.05, beta=0.1, elo0=0, elo1=10, ratinginterval=10
*TC*: 8s+0.08s
*Book*: 8moves_v3.epd
*Elo*: 8.3 +/- 11.4
```
Score of Maelstrom-RFP_Razoring_Update vs Maelstrom 2.1.0: 582 - 534 - 884  [0.512] 2000
...      Maelstrom-RFP_Razoring_Update playing White: 324 - 228 - 448  [0.548] 1000
...      Maelstrom-RFP_Razoring_Update playing Black: 258 - 306 - 436  [0.476] 1000
...      White vs Black: 630 - 486 - 884  [0.536] 2000
Elo difference: 8.3 +/- 11.4, LOS: 92.5 %, DrawRatio: 44.2 %
SPRT: llr 0.991 (34.3%), lbound -2.25, ubound 2.89

Player: Maelstrom-RFP_Razoring_Update
   "Draw by 3-fold repetition": 595
   "Draw by fifty moves rule": 163
   "Draw by insufficient mating material": 119
   "Draw by stalemate": 7
   "Loss: Black mates": 228
   "Loss: White mates": 306
   "Win: Black mates": 258
   "Win: White mates": 324
Player: Maelstrom 2.1.0
   "Draw by 3-fold repetition": 595
   "Draw by fifty moves rule": 163
   "Draw by insufficient mating material": 119
   "Draw by stalemate": 7
   "Loss: Black mates": 258
   "Loss: White mates": 324
   "Win: Black mates": 228
   "Win: White mates": 306
Finished match
```

**Changes:**
- Add documentation, motivations, conditions for each pruning technique as comments for reference
- Update conditions for RFP: instead of checking for mate, check that TT move exists and is not a capture
- Update conditions for Razoring: remove check condition and add conditions that TT move does not exist and that we are not searching for mate
- Fix NMP condition where we check that the position doesn't have just king and pawns. Previously was checking that the position contains only pawns, which doesn't make sense.