### PR TITLE
Edit search parameters based on SPSA tuning results

### DIFF
--- a/engine/tunable.go
+++ b/engine/tunable.go
@@ -15,15 +15,15 @@ type SearchParams struct {
 }
 
 var Params = SearchParams{
-	RFP_MULT:            120,
+	RFP_MULT:            132,
 	RFP_MAX_DEPTH:       9,
-	RAZORING_MULT:       220,
+	RAZORING_MULT:       228,
 	RAZORING_MAX_DEPTH:  2,
-	FUTILITY_BASE:       50,
-	FUTILITY_MULT:       150,
+	FUTILITY_BASE:       51,
+	FUTILITY_MULT:       142,
 	FUTILITY_MAX_DEPTH:  8,
 	IIR_MIN_DEPTH:       4,
 	IIR_DEPTH_REDUCTION: 1,
-	LMR_MIN_DEPTH:       3,
-	NMP_MIN_DEPTH:       3,
+	LMR_MIN_DEPTH:       2,
+	NMP_MIN_DEPTH:       2,
 }

--- a/engine/tunable.go
+++ b/engine/tunable.go
@@ -27,3 +27,5 @@ var Params = SearchParams{
 	LMR_MIN_DEPTH:       2,
 	NMP_MIN_DEPTH:       2,
 }
+
+var TUNING_EXPOSE_UCI = false

--- a/engine/tunable.go
+++ b/engine/tunable.go
@@ -1,0 +1,29 @@
+package engine
+
+type SearchParams struct {
+	RFP_MULT            int
+	RFP_MAX_DEPTH       int
+	RAZORING_MULT       int
+	RAZORING_MAX_DEPTH  int
+	FUTILITY_BASE       int
+	FUTILITY_MULT       int
+	FUTILITY_MAX_DEPTH  int
+	IIR_MIN_DEPTH       int
+	IIR_DEPTH_REDUCTION int
+	LMR_MIN_DEPTH       int
+	NMP_MIN_DEPTH       int
+}
+
+var Params = SearchParams{
+	RFP_MULT:            120,
+	RFP_MAX_DEPTH:       9,
+	RAZORING_MULT:       220,
+	RAZORING_MAX_DEPTH:  2,
+	FUTILITY_BASE:       50,
+	FUTILITY_MULT:       150,
+	FUTILITY_MAX_DEPTH:  8,
+	IIR_MIN_DEPTH:       4,
+	IIR_DEPTH_REDUCTION: 1,
+	LMR_MIN_DEPTH:       3,
+	NMP_MIN_DEPTH:       3,
+}

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -186,6 +187,14 @@ func UciLoop() {
 			fmt.Println("id name Maelstrom v3.0.0")
 			fmt.Println("id author Saigautam Bonam")
 			fmt.Println("option name Hash type spin default 256 min 1 max 4096")
+			val := reflect.ValueOf(Params)
+			typ := val.Type()
+
+			for i := 0; i < val.NumField(); i++ {
+				name := typ.Field(i).Name
+				defaultVal := val.Field(i).Int()
+				fmt.Printf("option name %s type spin default %d min 0 max 10000\n", name, defaultVal)
+			}
 			fmt.Println("uciok")
 		} else if command == "isready" {
 			fmt.Println("readyok")
@@ -210,9 +219,21 @@ func UciLoop() {
 			processGo(command, &b)
 		} else if strings.Contains(command, "setoption") {
 			words := strings.Split(command, " ")
-			if len(words) >= 5 && words[1] == "name" && words[2] == "Hash" && words[3] == "value" {
-				ttSize, _ = strconv.ParseInt(words[4], 10, 64)
-				InitializeTT(int(ttSize))
+			if len(words) >= 5 && words[1] == "name" && words[3] == "value" {
+				paramName := words[2]
+				paramValue, err := strconv.Atoi(words[4])
+				if err != nil {
+					fmt.Println("info string invalid value")
+					return
+				}
+
+				pVal := reflect.ValueOf(&Params).Elem()
+				pField := pVal.FieldByName(paramName)
+				if pField.IsValid() && pField.CanSet() && pField.Kind() == reflect.Int {
+					pField.SetInt(int64(paramValue))
+				} else if paramName == "Hash" {
+					InitializeTT(paramValue)
+				}
 			}
 		} else if command == "d" {
 			// Debug command to print current position

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -187,13 +187,16 @@ func UciLoop() {
 			fmt.Println("id name Maelstrom v3.0.0")
 			fmt.Println("id author Saigautam Bonam")
 			fmt.Println("option name Hash type spin default 256 min 1 max 4096")
-			val := reflect.ValueOf(Params)
-			typ := val.Type()
 
-			for i := 0; i < val.NumField(); i++ {
-				name := typ.Field(i).Name
-				defaultVal := val.Field(i).Int()
-				fmt.Printf("option name %s type spin default %d min 0 max 10000\n", name, defaultVal)
+			if TUNING_EXPOSE_UCI {
+				val := reflect.ValueOf(Params)
+				typ := val.Type()
+
+				for i := 0; i < val.NumField(); i++ {
+					name := typ.Field(i).Name
+					defaultVal := val.Field(i).Int()
+					fmt.Printf("option name %s type spin default %d min 0 max 10000\n", name, defaultVal)
+				}
 			}
 			fmt.Println("uciok")
 		} else if command == "isready" {


### PR DESCRIPTION
STC: 35.4 +/- 14.8
```
Score of Maelstrom TEST vs Maelstrom v3.0.0: 496 - 359 - 494  [0.551] 1349
...      Maelstrom TEST playing White: 266 - 173 - 235  [0.569] 674
...      Maelstrom TEST playing Black: 230 - 186 - 259  [0.533] 675
...      White vs Black: 452 - 403 - 494  [0.518] 1349
Elo difference: 35.4 +/- 14.8, LOS: 100.0 %, DrawRatio: 36.6 %
SPRT: llr 2.91 (100.7%), lbound -2.25, ubound 2.89 - H1 was accepted
```

LTC: 10.4 +/- 11.3
```
Score of Maelstrom TEST vs Maelstrom v3.0.0: 577 - 517 - 906  [0.515] 2000
...      Maelstrom TEST playing White: 331 - 228 - 441  [0.551] 1000
...      Maelstrom TEST playing Black: 246 - 289 - 465  [0.478] 1000
...      White vs Black: 620 - 474 - 906  [0.536] 2000
Elo difference: 10.4 +/- 11.3, LOS: 96.5 %, DrawRatio: 45.3 %
SPRT: llr 1.2 (41.5%), lbound -2.25, ubound 2.89
```

Features:
* Make existing search parameters as tunable parameters to be exposed via UCI
* Add a flag to actually print these parameters as supported from the UCI command
* Edit parameters to the results of an SPSA run (~17 hrs at STC)