### PR TITLE
Create timemanager and apply soft & hard timeouts

### DIFF
--- a/engine/movegen_test.go
+++ b/engine/movegen_test.go
@@ -355,7 +355,7 @@ func TestAllMovesMakeUnmake(t *testing.T) {
 	for _, m := range moves {
 		b.MakeMove(m)
 
-		_, _ = Perft(&b, 4)
+		Perft(&b, 4)
 		b.Undo()
 
 		newStats := fmt.Sprintf("Castling: %t %t %t %t, En passant: %q, Turn: %d, History: %d, Occupied: %d, Empty: %d, White: %d, Black: %d, Hash: %d\n", b.oo, b.ooo, b.OO, b.OOO, SQUARE_TO_STRING_MAP[b.enPassant], b.turn, len(b.history), b.occupied, b.empty, b.colors[WHITE], b.colors[BLACK], b.zobrist)

--- a/engine/perft.go
+++ b/engine/perft.go
@@ -18,24 +18,21 @@ func init() {
 	InitZobrist()
 }
 
-func Perft(b *Board, depth int) (int, int) {
+func Perft(b *Board, depth int) int {
 	moves := b.GenerateLegalMoves()
-	captures := b.GenerateCaptures()
 
 	if depth == 1 {
-		return len(moves), len(captures)
+		return len(moves)
 	}
 
 	var numNodes int = 0
-	var numCaptures int = 0
 	for _, move := range moves {
 		b.MakeMove(move)
-		n, c := Perft(b, depth-1)
+		n := Perft(b, depth-1)
 		numNodes += n
-		numCaptures += c
 		b.Undo()
 	}
-	return numNodes, numCaptures
+	return numNodes
 }
 
 func RunPerfTests(t *testing.T, position string, maxDepth int, expected int, expectedCaptures int) {
@@ -56,7 +53,7 @@ func RunPerfTests(t *testing.T, position string, maxDepth int, expected int, exp
 
 	for depth := 1; depth <= maxDepth; depth++ {
 		start := time.Now()
-		nodes, captures = Perft(&b, depth)
+		nodes = Perft(&b, depth)
 		duration := time.Since(start)
 		fmt.Printf("Depth %d, Nodes: %d, Captures: %d, Time: %d µs, NPS: %d\n", depth, nodes, captures, duration.Microseconds(), int(nodes*1000000000/(int(duration.Nanoseconds()+1))))
 
@@ -66,9 +63,9 @@ func RunPerfTests(t *testing.T, position string, maxDepth int, expected int, exp
 		t.Fatalf("TestPerft: got %d nodes, wanted %d", nodes, expected)
 	}
 
-	if expectedCaptures > 0 && expectedCaptures != captures {
-		t.Fatalf("TestPerft: got %d captures, wanted %d", captures, expectedCaptures)
-	}
+	// if expectedCaptures > 0 && captures > 0 && expectedCaptures != captures {
+	// 	t.Fatalf("TestPerft: got %d captures, wanted %d", captures, expectedCaptures)
+	// }
 }
 
 func RunTests(t *testing.T) {

--- a/engine/profiling.go
+++ b/engine/profiling.go
@@ -26,7 +26,8 @@ func SearchWithProfiling(b *Board, movetime int64) Move {
 	defer pprof.StopCPUProfile()
 
 	// Run the search
-	move := SearchWithTime(b, movetime)
+	Timer.SetMoveTime(movetime)
+	move := SearchPosition(b)
 
 	// Write memory profile
 	memFile, err := os.Create("mem.prof")

--- a/engine/run.go
+++ b/engine/run.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"fmt"
-	"strings"
 )
 
 func InitializeEverythingExceptTTable() {
@@ -26,17 +25,6 @@ func Run(command string, position string, depth int) {
 	if command == "search" {
 		RunSearch(position, depth)
 	}
-	if command == "selfplay" {
-		RunSelfPlay(position, depth)
-	}
-	if strings.Contains(command, "play") {
-		color := strings.Split(command, " ")[1]
-		if color == "white" {
-			RunPlay(position, depth, WHITE)
-		} else {
-			RunPlay(position, depth, BLACK)
-		}
-	}
 }
 
 func RunSearch(position string, depth int) {
@@ -59,7 +47,7 @@ func RunSearch(position string, depth int) {
 		score := Pvs(&b, i, i, -WIN_VAL-1, WIN_VAL+1, b.turn, true, &line)
 		score *= COLOR_SIGN[b.turn]
 
-		if SearchStop {
+		if Timer.Stop {
 			break
 		}
 
@@ -82,108 +70,4 @@ func RunSearch(position string, depth int) {
 	}
 
 	fmt.Println("Done")
-}
-
-func RunSelfPlay(position string, depth int) {
-	InitializeEverythingExceptTTable()
-	InitializeTT(256)
-	b := Board{}
-	if position == "startpos" {
-		b.InitStartPos()
-	} else {
-		fen := position
-		b.InitFEN(fen)
-	}
-
-	movesPlayed := []string{}
-
-	legals := b.GenerateLegalMoves()
-
-	for {
-		if len(legals) == 0 {
-			break
-		}
-
-		b.PrintFromBitBoards()
-		score := 0
-		bestMove := SearchWithTime(&b, 10000)
-		b.PrintFromBitBoards()
-
-		fmt.Printf("SCORE: %d\n", score*COLOR_SIGN[b.turn])
-
-		movesPlayed = append(movesPlayed, bestMove.ToUCI())
-		b.MakeMove(bestMove)
-
-		fmt.Println(movesPlayed)
-	}
-}
-
-func RunPlay(position string, depth int, player Color) {
-	InitializeEverythingExceptTTable()
-	InitializeTT(256)
-	b := Board{}
-	if position == "startpos" {
-		b.InitStartPos()
-	} else {
-		fen := position
-		b.InitFEN(fen)
-	}
-	movesPlayed := []string{}
-
-	legals := b.GenerateLegalMoves()
-	for {
-		if len(legals) == 0 {
-			break
-		}
-
-		b.PrintFromBitBoards()
-
-		if b.turn == player {
-			fmt.Println("Your turn: ")
-			var move string
-
-			fmt.Scanln(&move)
-
-			b.MakeMoveFromUCI(move)
-			movesPlayed = append(movesPlayed, move)
-		} else {
-			line := []Move{}
-
-			score := 0
-
-			for i := 1; i <= depth; i++ {
-				line = []Move{}
-
-				fmt.Printf("Depth %d: ", i)
-
-				score = Pvs(&b, i, i, -WIN_VAL-1, WIN_VAL+1, b.turn, true, &line)
-
-				if score == WIN_VAL || score == -WIN_VAL {
-					fmt.Println("Found mate.")
-					break
-				}
-
-				fmt.Print(score * COLOR_SIGN[b.turn])
-				fmt.Print(" ")
-
-				strLine := []string{}
-				for i, _ := range line {
-					strLine = append(strLine, line[i].ToUCI())
-				}
-
-				fmt.Print(strLine)
-				fmt.Println()
-
-			}
-			bestMove := line[0]
-
-			fmt.Printf("SCORE: %d\n", score*COLOR_SIGN[b.turn])
-
-			movesPlayed = append(movesPlayed, bestMove.ToUCI())
-			b.MakeMove(bestMove)
-
-			fmt.Print("Moves played: ")
-			fmt.Println(movesPlayed)
-		}
-	}
 }

--- a/engine/search.go
+++ b/engine/search.go
@@ -459,9 +459,6 @@ func SearchPosition(b *Board) Move {
 		// Aspiration window search with exponentially-widening research on fail
 		for {
 			score = Pvs(b, depth, depth, alpha, beta, b.turn, true, &line)
-
-			Timer.CheckID(depth)
-
 			if Timer.Stop {
 				fmt.Printf("returning prev best move after %d\n", Timer.Delta())
 				return prevBest
@@ -499,6 +496,12 @@ func SearchPosition(b *Board) Move {
 		}
 
 		prevBest = line[0]
+
+		Timer.CheckID(depth)
+		if Timer.Stop {
+			fmt.Printf("returning prev best move after %d\n", Timer.Delta())
+			return prevBest
+		}
 	}
 	return prevBest
 }

--- a/engine/search.go
+++ b/engine/search.go
@@ -407,6 +407,27 @@ func updateHistory(move Move, color Color, bonus int) {
 	HistoryTable[color][move.from][move.to] += bonus - HistoryTable[color][move.from][move.to]*absBonus/HISTORY_MAX_BONUS
 }
 
+func ClearKillers() {
+	for i := 0; i < len(KillerMovesTable); i++ {
+		KillerMovesTable[i][0] = Move{}
+		KillerMovesTable[i][1] = Move{}
+	}
+}
+
+func ClearHistory() {
+	HistoryTable = [2][64][64]int{}
+}
+
+func HalfHistory() {
+	for c := 0; c < 2; c++ {
+		for from := 0; from < 64; from++ {
+			for to := 0; to < 64; to++ {
+				HistoryTable[c][from][to] /= 2
+			}
+		}
+	}
+}
+
 func InitializeLMRTable() {
 	for depth := 1; depth <= 100; depth++ {
 		for moveCnt := 1; moveCnt <= 100; moveCnt++ {
@@ -439,6 +460,7 @@ func SearchWithTime(b *Board, movetime int64) Move {
 
 	// Set prevBest to first legal move in case search is stopped immediately
 	prevBest := legalMoves[0]
+	HalfHistory()
 
 	for i := 1; i <= 100; i++ {
 		NodesSearched = 0

--- a/engine/search.go
+++ b/engine/search.go
@@ -34,25 +34,14 @@ var HistoryTable = [2][64][64]int{}
 
 var NodesSearched = 0
 
-// Global variables for PVS to keep track of search time
-// Defaults to 10 sec/search but these values are changed in searchWithTime
-var SearchStartTime time.Time = time.Now()
-var AllowedTime int64 = 10000
-var SearchStop = false
-
 func QuiescenceSearch(b *Board, alpha int, beta int, c Color) int {
 	NodesSearched++
 
-	// Check for stop signal
-	select {
-	case <-StopChannel:
-		SearchStop = true
-		return 0
-	default:
-		// Continue search
+	if NodesSearched%2047 == 0 {
+		Timer.CheckPVS()
 	}
 
-	if SearchStop {
+	if Timer.Stop {
 		return 0
 	}
 
@@ -75,7 +64,7 @@ func QuiescenceSearch(b *Board, alpha int, beta int, c Color) int {
 		score := -QuiescenceSearch(b, -beta, -alpha, ReverseColor(c))
 		b.Undo()
 
-		if SearchStop {
+		if Timer.Stop {
 			return 0
 		}
 
@@ -132,22 +121,11 @@ func selectMove(idx int, moves []Move, b *Board, pv Move, depth int) Move {
 func Pvs(b *Board, depth int, rd int, alpha int, beta int, c Color, doNull bool, line *[]Move) int {
 	NodesSearched++
 
-	// Check for stop signal
-	select {
-	case <-StopChannel:
-		SearchStop = true
-		return 0
-	default:
-		// Continue search
+	if NodesSearched%2047 == 0 {
+		Timer.CheckPVS()
 	}
 
-	if SearchStop {
-		return 0
-	}
-
-	if NodesSearched%2047 == 0 && time.Since(SearchStartTime).Milliseconds() > AllowedTime {
-		fmt.Printf("stopping search after %d\n", time.Since(SearchStartTime).Milliseconds())
-		SearchStop = true
+	if Timer.Stop {
 		return 0
 	}
 
@@ -239,7 +217,7 @@ func Pvs(b *Board, depth int, rd int, alpha int, beta int, c Color, doNull bool,
 
 			childPV = []Move{}
 
-			if SearchStop {
+			if Timer.Stop {
 				return 0
 			}
 
@@ -339,7 +317,7 @@ func Pvs(b *Board, depth int, rd int, alpha int, beta int, c Color, doNull bool,
 
 		b.Undo()
 
-		if SearchStop {
+		if Timer.Stop {
 			return 0
 		}
 
@@ -378,7 +356,7 @@ func Pvs(b *Board, depth int, rd int, alpha int, beta int, c Color, doNull bool,
 		childPV = []Move{}
 	}
 
-	if !SearchStop {
+	if !Timer.Stop {
 		StoreEntry(b, bestScore, ttFlag, bestMove, uint8(depth))
 	}
 
@@ -437,13 +415,9 @@ func InitializeLMRTable() {
 	}
 }
 
-// SearchWithTime searches for the best move given a time constraint
-func SearchWithTime(b *Board, movetime int64) Move {
-	fmt.Printf("searching for movetime %d\n", movetime)
-
-	SearchStartTime = time.Now()
-	AllowedTime = movetime
-	SearchStop = false
+func SearchPosition(b *Board) Move {
+	Timer.StartSearch()
+	Timer.PrintConditions()
 
 	line := []Move{}
 	legalMoves := b.GenerateLegalMoves()
@@ -460,9 +434,11 @@ func SearchWithTime(b *Board, movetime int64) Move {
 
 	// Set prevBest to first legal move in case search is stopped immediately
 	prevBest := legalMoves[0]
+
+	// Half the history heuristic values after each search
 	HalfHistory()
 
-	for i := 1; i <= 100; i++ {
+	for depth := 1; depth <= 100; depth++ {
 		NodesSearched = 0
 		searchStart := time.Now()
 
@@ -473,7 +449,7 @@ func SearchWithTime(b *Board, movetime int64) Move {
 		alphaWindowSize := -25
 		betaWindowSize := 25
 
-		if i > 5 {
+		if depth > 5 {
 			alpha = prevScore + alphaWindowSize
 			beta = prevScore + betaWindowSize
 		}
@@ -482,9 +458,12 @@ func SearchWithTime(b *Board, movetime int64) Move {
 
 		// Aspiration window search with exponentially-widening research on fail
 		for {
-			score = Pvs(b, i, i, alpha, beta, b.turn, true, &line)
-			if SearchStop {
-				fmt.Printf("returning prev best move after %d\n", time.Since(SearchStartTime).Milliseconds())
+			score = Pvs(b, depth, depth, alpha, beta, b.turn, true, &line)
+
+			Timer.CheckID(depth)
+
+			if Timer.Stop {
+				fmt.Printf("returning prev best move after %d\n", Timer.Delta())
 				return prevBest
 			}
 
@@ -513,7 +492,7 @@ func SearchWithTime(b *Board, movetime int64) Move {
 		}
 
 		nps := NodesSearched * 1000000000 / Max(int(timeTakenNanoSeconds), 1)
-		fmt.Printf("info depth %d nodes %d time %d score cp %d nps %d pv%s\n", i, NodesSearched, timeTaken, score, nps, strLine)
+		fmt.Printf("info depth %d nodes %d time %d score cp %d nps %d pv%s\n", depth, NodesSearched, timeTaken, score, nps, strLine)
 
 		if score == WIN_VAL || score == -WIN_VAL {
 			return line[0]

--- a/engine/time.go
+++ b/engine/time.go
@@ -1,0 +1,144 @@
+package engine
+
+import (
+	"fmt"
+	"time"
+)
+
+const INF_TIME = 10000000 // Time for `go infinite`
+
+type TimeManager struct {
+	softLimit       int64 // Soft limit, checked at the end of each ID iteration
+	hardLimit       int64 // Hard limit, checked during search
+	searchStartTime time.Time
+	wTime           int64
+	bTime           int64
+	wInc            int64
+	bInc            int64
+	movesToGo       int64
+	moveTime        int64 // Will be 0 if movetime not specified
+	maxDepth        int64 // Will be 0 if max depth not specified
+	maxNodes        int64 // Will be 0 if max nodes not specified
+	infinite        bool
+	Stop            bool // If set to true, will immediately stop search
+}
+
+var Timer TimeManager
+
+func (t *TimeManager) Calculate(c Color, wtime int64, btime int64, winc int64, binc int64, movestogo int64, depth int64, nodes int64, movetime int64, infinite bool) {
+	t.wTime = wtime
+	t.wInc = winc
+	t.bTime = btime
+	t.bInc = binc
+	t.movesToGo = movestogo
+	t.maxDepth = depth
+	t.maxNodes = nodes
+	t.moveTime = movetime
+	t.infinite = infinite
+
+	if infinite {
+		t.softLimit = INF_TIME
+		t.hardLimit = INF_TIME
+		t.moveTime = INF_TIME
+		return
+	}
+
+	if movetime > 0 {
+		t.softLimit = movetime
+		t.hardLimit = movetime
+		return
+	}
+
+	if depth > 0 {
+		// Searching up to a max depth, so set time bounds to infinite and nodes to -1
+		t.softLimit = INF_TIME
+		t.hardLimit = INF_TIME
+		return
+	}
+
+	if nodes > 0 {
+		// Searching up to a max number of nodes, so set time bounds to infinite and depth to -1
+		t.softLimit = INF_TIME
+		t.hardLimit = INF_TIME
+		return
+	}
+
+	remainingTime := ternary(c == WHITE, t.wTime, t.bTime)
+	increment := ternary(c == WHITE, t.wInc, t.bInc)
+
+	// General time management formula
+	if t.movesToGo > 0 {
+		t.softLimit = remainingTime/t.movesToGo + increment/Params.INC_FRACTION
+	} else {
+		t.softLimit = remainingTime/Params.TIME_DIVISOR + increment/Params.INC_FRACTION
+	}
+
+	t.hardLimit = t.softLimit * Params.HARD_LIMIT_MULT
+
+	// Cap hard and soft limits to the remainingTime - 200 so we don't flag
+	if t.hardLimit > remainingTime-200 {
+		t.hardLimit = remainingTime - 200
+	}
+
+	if t.softLimit > remainingTime-200 {
+		t.softLimit = remainingTime - 200
+	}
+}
+
+// Primarily for tests
+func (t *TimeManager) SetMoveTime(movetime int64) {
+	t.hardLimit = movetime
+	t.softLimit = movetime
+	t.maxNodes = 0
+	t.maxDepth = 0
+}
+
+func (t *TimeManager) StartSearch() {
+	t.searchStartTime = time.Now()
+	t.Stop = false
+}
+
+func (t *TimeManager) Delta() int64 {
+	return time.Since(t.searchStartTime).Milliseconds()
+}
+
+// Only called during PVS, checks hard limit timeout and nodes
+func (t *TimeManager) CheckPVS() {
+	if t.Delta() > t.hardLimit {
+		t.Stop = true
+	}
+
+	if t.maxNodes > 0 && NodesSearched > int(t.maxNodes) {
+		t.Stop = true
+	}
+}
+
+// Called during iterative deepening, checks soft limit, nodes, current depth
+// TODO: add soft time bound scaling based on ID statistics
+func (t *TimeManager) CheckID(depth int) {
+	if t.Delta() > t.softLimit {
+		t.Stop = true
+	}
+
+	if t.maxNodes > 0 && NodesSearched > int(t.maxNodes) {
+		t.Stop = true
+	}
+
+	if t.maxDepth > 0 && depth > int(t.maxDepth) {
+		t.Stop = true
+	}
+}
+
+func (t *TimeManager) PrintConditions() {
+	fmt.Println("searching with conditions: ")
+	fmt.Printf("\thard limit: %d\n", t.hardLimit)
+	fmt.Printf("\tsoft limit: %d\n", t.softLimit)
+
+	if t.maxNodes > 0 {
+		fmt.Printf("\tmax nodes: %d\n", t.maxNodes)
+	}
+
+	if t.maxDepth > 0 {
+		fmt.Printf("\tmax depth: %d\n", t.maxDepth)
+	}
+}

--- a/engine/time.go
+++ b/engine/time.go
@@ -124,7 +124,7 @@ func (t *TimeManager) CheckID(depth int) {
 		t.Stop = true
 	}
 
-	if t.maxDepth > 0 && depth > int(t.maxDepth) {
+	if t.maxDepth > 0 && depth >= int(t.maxDepth) {
 		t.Stop = true
 	}
 }

--- a/engine/tunable.go
+++ b/engine/tunable.go
@@ -1,6 +1,6 @@
 package engine
 
-type SearchParams struct {
+type TunableParameters struct {
 	RFP_MULT            int
 	RFP_MAX_DEPTH       int
 	RAZORING_MULT       int
@@ -12,9 +12,12 @@ type SearchParams struct {
 	IIR_DEPTH_REDUCTION int
 	LMR_MIN_DEPTH       int
 	NMP_MIN_DEPTH       int
+	TIME_DIVISOR        int64
+	INC_FRACTION        int64
+	HARD_LIMIT_MULT     int64
 }
 
-var Params = SearchParams{
+var Params = TunableParameters{
 	RFP_MULT:            132,
 	RFP_MAX_DEPTH:       9,
 	RAZORING_MULT:       228,
@@ -26,6 +29,9 @@ var Params = SearchParams{
 	IIR_DEPTH_REDUCTION: 1,
 	LMR_MIN_DEPTH:       2,
 	NMP_MIN_DEPTH:       2,
+	TIME_DIVISOR:        25,
+	INC_FRACTION:        2,
+	HARD_LIMIT_MULT:     2,
 }
 
 var TUNING_EXPOSE_UCI = false

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -7,15 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 )
-
-// Global channel to signal search stop
-var StopChannel chan struct{}
-var SearchMutex sync.Mutex
-var IsSearching bool
-var UseOpeningBook bool = false
-var UseTablebase bool = false
 
 func processPosition(command string) Board {
 	b := Board{}
@@ -52,23 +44,10 @@ func processPosition(command string) Board {
 }
 
 func processGo(command string, b *Board) {
-	SearchMutex.Lock()
-	if IsSearching {
-		SearchMutex.Unlock()
-		return
-	}
-	IsSearching = true
-	SearchMutex.Unlock()
-
-	// Create a new stop channel for this search
-	StopChannel = make(chan struct{})
-
 	words := strings.Split(command, " ")
 
-	var wtime, btime, winc, binc, depth, movetime int64
+	var wtime, btime, winc, binc, depth, movetime, nodes, movestogo int64
 	var infinite bool
-	movetimeSet := false
-	movesToGo := int64(-1)
 
 	for i := 0; i < len(words); i++ {
 		switch words[i] {
@@ -79,9 +58,13 @@ func processGo(command string, b *Board) {
 				depth, _ = strconv.ParseInt(words[i+1], 10, 64)
 				i++
 			}
+		case "nodes":
+			if i+1 < len(words) {
+				nodes, _ = strconv.ParseInt(words[i+1], 10, 64)
+				i++
+			}
 		case "movetime":
 			if i+1 < len(words) {
-				movetimeSet = true
 				movetime, _ = strconv.ParseInt(words[i+1], 10, 64)
 				i++
 			}
@@ -107,66 +90,18 @@ func processGo(command string, b *Board) {
 			}
 		case "movestogo":
 			if i+1 < len(words) {
-				movesToGo, _ = strconv.ParseInt(words[i+1], 10, 64)
+				movestogo, _ = strconv.ParseInt(words[i+1], 10, 64)
 				i++
 			}
 		}
 	}
 
+	Timer.Calculate(b.turn, wtime, btime, winc, binc, movestogo, depth, nodes, movetime, infinite)
+
 	// Start search in a goroutine
 	go func() {
-		var bestMove Move
-
-		if infinite {
-			movetime = 1000000000 // Use a very large time for infinite search
-		} else if depth > 0 {
-			movetime = 1000000000 // Use a very large time when searching to a specific depth
-		} else if movetimeSet {
-			// Use specified movetime
-		} else if movesToGo > 0 {
-			if b.turn == WHITE {
-				movetime = wtime/movesToGo - 400
-			} else {
-				movetime = btime/movesToGo - 400
-			}
-		} else {
-			// Calculate time based on remaining time and increment
-			if b.turn == WHITE {
-				if winc >= 0 {
-					movetime = wtime/25 + winc - 200
-				} else {
-					movetime = wtime / 30
-				}
-
-				// Just to ensure engine doesn't flag when playing on lichess
-				if movetime > wtime-500 {
-					fmt.Println("shortening movetime to avoid flagging")
-					movetime = wtime - 500
-				}
-			} else {
-				if binc >= 0 {
-					movetime = btime/25 + binc - 200
-				} else {
-					movetime = btime / 30
-				}
-
-				// Just to ensure engine doesn't flag when playing on lichess
-				if movetime > btime-500 {
-					fmt.Println("shortening movetime to avoid flagging")
-					movetime = btime - 500
-				}
-			}
-		}
-
-		bestMove = SearchWithTime(b, movetime)
-
-		// Only output bestmove if we're still searching (i.e., not stopped)
-		SearchMutex.Lock()
-		if IsSearching {
-			fmt.Println("bestmove " + bestMove.ToUCI())
-		}
-		IsSearching = false
-		SearchMutex.Unlock()
+		bestMove := SearchPosition(b)
+		fmt.Println("bestmove " + bestMove.ToUCI())
 	}()
 }
 
@@ -210,11 +145,7 @@ func UciLoop() {
 		} else if command == "quit" {
 			os.Exit(0)
 		} else if command == "stop" {
-			SearchMutex.Lock()
-			if IsSearching && StopChannel != nil {
-				close(StopChannel)
-			}
-			SearchMutex.Unlock()
+			Timer.Stop = true
 		} else if command == "ponderhit" {
 			// Currently we don't support pondering, so treat it like a regular move
 			continue

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -205,6 +205,8 @@ func UciLoop() {
 			b = Board{}
 			b.InitStartPos()
 			ClearTT()
+			ClearHistory()
+			ClearKillers()
 		} else if command == "quit" {
 			os.Exit(0)
 		} else if command == "stop" {


### PR DESCRIPTION
STC: 141.4 +/- 32.4
```
Score of Maelstrom TEST vs Maelstrom main: 162 - 42 - 107  [0.693] 311
...      Maelstrom TEST playing White: 84 - 18 - 54  [0.712] 156
...      Maelstrom TEST playing Black: 78 - 24 - 53  [0.674] 155
...      White vs Black: 108 - 96 - 107  [0.519] 311
Elo difference: 141.4 +/- 32.4, LOS: 100.0 %, DrawRatio: 34.4 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```

LTC: 25.1 +/- 24.9
```
Score of Maelstrom TEST vs Maelstrom main: 100 - 74 - 187  [0.536] 361
...      Maelstrom TEST playing White: 56 - 29 - 95  [0.575] 180
...      Maelstrom TEST playing Black: 44 - 45 - 92  [0.497] 181
...      White vs Black: 101 - 73 - 187  [0.539] 361
Elo difference: 25.1 +/- 24.9, LOS: 97.6 %, DrawRatio: 51.8 %
SPRT: llr 0.703 (24.3%), lbound -2.25, ubound 2.89
```

## Features
* Clear history and killer tables on ucinewgame
* When new search is started, halve all history values by 2
* Add time manager with soft/hard timeouts as well as support for maximum nodes