### PR TITLE
Add SEE for QS pruning, PVS quiet move pruning, move ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ cutechess-cli -engine proto=uci cmd={BINARY_TO_TEST} name={TEST_NAME} -engine pr
   - [Viridithas](https://github.com/cosmobobak/viridithas)
   - [Alexandria](https://github.com/PGG106/Alexandria)
   - [Stash](https://gitlab.com/mhouppin/stash-bot)
+  - [Starzix](https://github.com/zzzzz151/Starzix)
   - and many more open-source engines, these are just the ones I can name off the top of my head!
 - [bullet](https://github.com/jw1912/bullet) for allowing me to easily train the NNUE.
 - Engine Programmers and Stockfish discord servers for their huge knowledge base/resources and advice.

--- a/engine/move.go
+++ b/engine/move.go
@@ -78,6 +78,8 @@ func FromUCI(uci string, b *Board) Move {
 			m.movetype = CAPTURE
 		}
 		m.captured = b.squares[to]
+	} else {
+		m.captured = EMPTY
 	}
 
 	if (from == E1 && to == G1 && m.piece == W_K) || (from == E8 && to == G8 && m.piece == B_K) {
@@ -93,6 +95,7 @@ func FromUCI(uci string, b *Board) Move {
 
 	if m.piece == W_P && !(oneSquare || twoSquares) && m.movetype == QUIET {
 		m.movetype = EN_PASSANT
+		m.captured = B_P
 	}
 
 	oneSquare = int(to-from) == int(SOUTH)
@@ -100,6 +103,7 @@ func FromUCI(uci string, b *Board) Move {
 
 	if m.piece == B_P && !(oneSquare || twoSquares) && m.movetype == QUIET {
 		m.movetype = EN_PASSANT
+		m.captured = W_P
 	}
 
 	return m

--- a/engine/search.go
+++ b/engine/search.go
@@ -58,7 +58,7 @@ func QuiescenceSearch(b *Board, alpha int, beta int, c Color) int {
 
 	moves := b.GenerateCaptures()
 
-	for mvCnt, _ := range moves {
+	for mvCnt := range moves {
 		move := selectMove(mvCnt, moves, b, Move{}, 0)
 		if move.movetype != CAPTURE_AND_PROMOTION && see(b, move) < 0 {
 			continue
@@ -267,6 +267,10 @@ func Pvs(b *Board, depth int, rd int, alpha int, beta int, c Color, doNull bool,
 		isQuiet := move.movetype == QUIET || move.movetype == K_CASTLE || move.movetype == Q_CASTLE
 
 		if isQuiet {
+			// SEE pruning of quiet moves
+			if !isPv && bestScore > -WIN_VAL+100 && depth <= Params.SEE_QUIET_PRUNING_MAX_DEPTH && see(b, move) < -Params.SEE_QUIET_PRUNING_MULT*depth {
+				continue
+			}
 			quietsSearched = append(quietsSearched, move)
 		}
 

--- a/engine/search.go
+++ b/engine/search.go
@@ -60,6 +60,10 @@ func QuiescenceSearch(b *Board, alpha int, beta int, c Color) int {
 
 	for mvCnt, _ := range moves {
 		move := selectMove(mvCnt, moves, b, Move{}, 0)
+		if move.movetype != CAPTURE_AND_PROMOTION && see(b, move) < 0 {
+			continue
+		}
+
 		b.MakeMove(move)
 		score := -QuiescenceSearch(b, -beta, -alpha, ReverseColor(c))
 		b.Undo()

--- a/engine/see.go
+++ b/engine/see.go
@@ -1,0 +1,71 @@
+package engine
+
+var SEE_PIECE_VALUES = [6]int{
+	100,
+	300,
+	300,
+	500,
+	900,
+	WIN_VAL,
+}
+
+// STATIC EXCHANGE EVALUATION
+//
+//	We can prune some captures by doing a unary tree search to determine if the capture is ideal or not.
+//	At each step, we just choose the least valuable attacker of the square we move to and check if it can
+//	capture the square the move went to. Once we do this until there are no more captures left to that square,
+//	we'll have a decent idea how much this capture gains/loses material.
+//
+//	NOTE - currently doesn't work for quiet moves, promotions, or promotions which capture a piece
+//
+// Pseudocode implementation from https://www.chessprogramming.org/SEE_-_The_Swap_Algorithm
+func see(b *Board, move Move) int {
+	gain := [32]int{}
+	d := 0
+	mayXRay := b.occupied & ^(b.pieces[W_K] | b.pieces[W_N] | b.pieces[B_K] | b.pieces[B_N]) // pawns, bishops, rooks. queens
+	fromSet := SQUARE_TO_BITBOARD[move.from]
+	occ := b.occupied ^ SQUARE_TO_BITBOARD[move.from] ^ SQUARE_TO_BITBOARD[move.to]
+	attadef := b.AllAttackersOf(move.to, occ)
+
+	stm := ReverseColor(b.turn)
+	target := PieceToPieceType(move.captured)
+	attacker := PieceToPieceType(move.piece)
+	seen := u64(0)
+
+	gain[d] = SEE_PIECE_VALUES[target]
+
+	for fromSet != 0 {
+		d++
+		gain[d] = SEE_PIECE_VALUES[attacker] - gain[d-1]
+		attadef &= ^fromSet
+		occ &= ^fromSet
+		seen |= fromSet
+
+		if fromSet&mayXRay != 0 {
+			attadef |= b.XRayAttacks(move.to, occ) & ^seen
+		}
+
+		fromSet = getLeastValuablePiece(b, attadef, stm, &attacker)
+
+		stm = ReverseColor(stm)
+	}
+
+	// Negamax-ing gains
+	for d > 1 {
+		d--
+		gain[d-1] = -Max(-gain[d-1], gain[d])
+	}
+
+	return gain[0]
+}
+
+func getLeastValuablePiece(b *Board, attadef u64, stm Color, piece *PieceType) u64 {
+	for *piece = PAWN; *piece <= KING; *piece++ {
+		subset := attadef & b.GetColorPieces(*piece, stm)
+		if subset != 0 {
+			return subset & -subset
+		}
+	}
+
+	return 0
+}

--- a/engine/see.go
+++ b/engine/see.go
@@ -16,8 +16,6 @@ var SEE_PIECE_VALUES = [6]int{
 //	capture the square the move went to. Once we do this until there are no more captures left to that square,
 //	we'll have a decent idea how much this capture gains/loses material.
 //
-//	NOTE - currently doesn't work for quiet moves, promotions, or promotions which capture a piece
-//
 // Pseudocode implementation from https://www.chessprogramming.org/SEE_-_The_Swap_Algorithm
 func see(b *Board, move Move) int {
 	gain := [32]int{}
@@ -28,11 +26,15 @@ func see(b *Board, move Move) int {
 	attadef := b.AllAttackersOf(move.to, occ)
 
 	stm := ReverseColor(b.turn)
-	target := PieceToPieceType(move.captured)
+	initial_gain := 0
+	if move.captured != EMPTY {
+		initial_gain += SEE_PIECE_VALUES[PieceToPieceType(move.captured)]
+	}
+
 	attacker := PieceToPieceType(move.piece)
 	seen := u64(0)
 
-	gain[d] = SEE_PIECE_VALUES[target]
+	gain[d] = initial_gain
 
 	for fromSet != 0 {
 		d++

--- a/engine/see_test.go
+++ b/engine/see_test.go
@@ -1,0 +1,51 @@
+package engine
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestSee(t *testing.T) {
+	file, err := os.Open("test_data/see_test.txt")
+	if err != nil {
+		fmt.Println("Error opening file:", err)
+		return
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Split(line, "|")
+
+		fen := strings.TrimSpace(parts[0])
+		uci := strings.TrimSpace(parts[1])
+		scoreStr := strings.TrimSpace(parts[2])
+		score, _ := strconv.Atoi(scoreStr)
+
+		fmt.Println("FEN:", fen)
+		fmt.Println("Move:", uci)
+		fmt.Println("Score:", score)
+		fmt.Println()
+
+		b := Board{}
+		b.InitFEN(fen + " 0 1")
+		move := FromUCI(uci, &b)
+		if move.movetype == QUIET || move.movetype == PROMOTION || move.movetype == K_CASTLE || move.movetype == Q_CASTLE || move.movetype == CAPTURE_AND_PROMOTION {
+			fmt.Println("skipping since move isn't a capture")
+			continue
+		}
+
+		b.PrintFromBitBoards()
+		res := see(&b, move)
+
+		fmt.Printf("\n\n")
+		if res != score {
+			t.Fatalf("Expected %d, got %d", score, res)
+		}
+	}
+}

--- a/engine/see_test.go
+++ b/engine/see_test.go
@@ -35,12 +35,12 @@ func TestSee(t *testing.T) {
 		b := Board{}
 		b.InitFEN(fen + " 0 1")
 		move := FromUCI(uci, &b)
-		if move.movetype == QUIET || move.movetype == PROMOTION || move.movetype == K_CASTLE || move.movetype == Q_CASTLE || move.movetype == CAPTURE_AND_PROMOTION {
-			fmt.Println("skipping since move isn't a capture")
+
+		if move.promote != EMPTY {
+			fmt.Println("skip promotion")
 			continue
 		}
 
-		b.PrintFromBitBoards()
 		res := see(&b, move)
 
 		fmt.Printf("\n\n")

--- a/engine/tunable.go
+++ b/engine/tunable.go
@@ -1,37 +1,41 @@
 package engine
 
 type TunableParameters struct {
-	RFP_MULT            int
-	RFP_MAX_DEPTH       int
-	RAZORING_MULT       int
-	RAZORING_MAX_DEPTH  int
-	FUTILITY_BASE       int
-	FUTILITY_MULT       int
-	FUTILITY_MAX_DEPTH  int
-	IIR_MIN_DEPTH       int
-	IIR_DEPTH_REDUCTION int
-	LMR_MIN_DEPTH       int
-	NMP_MIN_DEPTH       int
-	TIME_DIVISOR        int64
-	INC_FRACTION        int64
-	HARD_LIMIT_MULT     int64
+	RFP_MULT                    int
+	RFP_MAX_DEPTH               int
+	RAZORING_MULT               int
+	RAZORING_MAX_DEPTH          int
+	FUTILITY_BASE               int
+	FUTILITY_MULT               int
+	FUTILITY_MAX_DEPTH          int
+	IIR_MIN_DEPTH               int
+	IIR_DEPTH_REDUCTION         int
+	LMR_MIN_DEPTH               int
+	NMP_MIN_DEPTH               int
+	SEE_QUIET_PRUNING_MAX_DEPTH int
+	SEE_QUIET_PRUNING_MULT      int
+	TIME_DIVISOR                int64
+	INC_FRACTION                int64
+	HARD_LIMIT_MULT             int64
 }
 
 var Params = TunableParameters{
-	RFP_MULT:            132,
-	RFP_MAX_DEPTH:       9,
-	RAZORING_MULT:       228,
-	RAZORING_MAX_DEPTH:  2,
-	FUTILITY_BASE:       51,
-	FUTILITY_MULT:       142,
-	FUTILITY_MAX_DEPTH:  8,
-	IIR_MIN_DEPTH:       4,
-	IIR_DEPTH_REDUCTION: 1,
-	LMR_MIN_DEPTH:       2,
-	NMP_MIN_DEPTH:       2,
-	TIME_DIVISOR:        25,
-	INC_FRACTION:        2,
-	HARD_LIMIT_MULT:     2,
+	RFP_MULT:                    132,
+	RFP_MAX_DEPTH:               9,
+	RAZORING_MULT:               228,
+	RAZORING_MAX_DEPTH:          2,
+	FUTILITY_BASE:               51,
+	FUTILITY_MULT:               142,
+	FUTILITY_MAX_DEPTH:          8,
+	IIR_MIN_DEPTH:               4,
+	IIR_DEPTH_REDUCTION:         1,
+	LMR_MIN_DEPTH:               2,
+	NMP_MIN_DEPTH:               2,
+	SEE_QUIET_PRUNING_MAX_DEPTH: 10,
+	SEE_QUIET_PRUNING_MULT:      35,
+	TIME_DIVISOR:                25,
+	INC_FRACTION:                2,
+	HARD_LIMIT_MULT:             2,
 }
 
 var TUNING_EXPOSE_UCI = false


### PR DESCRIPTION
STC ELO: 94.3 +/- 25.4
```
Score of Maelstrom TEST vs Maelstrom main: 199 - 79 - 175  [0.632] 453
...      Maelstrom TEST playing White: 110 - 30 - 87  [0.676] 227
...      Maelstrom TEST playing Black: 89 - 49 - 88  [0.588] 226
...      White vs Black: 159 - 119 - 175  [0.544] 453
Elo difference: 94.3 +/- 25.4, LOS: 100.0 %, DrawRatio: 38.6 %
SPRT: llr 2.9 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
```

LTC ELO: 79.9 +/- 23.2
```
Score of Maelstrom TEST vs Maelstrom main: 194 - 83 - 214  [0.613] 491
...      Maelstrom TEST playing White: 110 - 35 - 100  [0.653] 245
...      Maelstrom TEST playing Black: 84 - 48 - 114  [0.573] 246
...      White vs Black: 158 - 119 - 214  [0.540] 491
Elo difference: 79.9 +/- 23.2, LOS: 100.0 %, DrawRatio: 43.6 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```